### PR TITLE
Remove unnecessary requires and dependency from 'global-modules'

### DIFF
--- a/manager/utils.js
+++ b/manager/utils.js
@@ -1,7 +1,6 @@
 var fs = require('fs-extra'),
     chalk = require('chalk'),
     inquirer = require('inquirer'),
-    dir = require('global-modules'),
     mkdirp = require('mkdirp'),
     isWindows = require('is-windows'),
     pjson = require('../package.json'),

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "commander": "^2.9.0",
     "cwd": "^0.10.0",
     "fs-extra": "^0.28.0",
-    "global-modules": "^0.2.2",
     "inquirer": "^1.0.2",
     "is-windows": "^0.2.0",
     "mkdirp": "^0.5.1"


### PR DESCRIPTION
Hey @NonPolynomial, great fix, just finished your work by removing the unnecessary require() and dependency of 'global-modules'.

The added benefit of your change is that with it you're able to install and use astrum locally, which is great for CI environments. 

When you add my changes to your pull request in the original repo, I'll ask again, to see if we could get this tiny fix merged. I tested it in a Mac and a Windows 7 VM as well. The fix works well in both.

Cheers!
